### PR TITLE
Revert "Bump pillow from 9.5.0 to 10.0.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ numpy==1.25.1
 packaging==23.1
 pandas==2.0.3
 pathy==0.10.2
-Pillow==10.0.1
+Pillow==9.5.0
 plotly==5.15.0
 preshed==3.0.8
 protobuf==4.23.4


### PR DESCRIPTION
Reverts imhalcyon/Resume-Matcher#3

Causes issues with streamlit and matplotlib

 The user requested Pillow==10.0.1
    matplotlib 3.7.2 depends on pillow>=6.2.0
    streamlit 1.27.0 depends on pillow<10 and >=7.1.0
